### PR TITLE
chore/parallel_api_feature_tests

### DIFF
--- a/src/MasterData/MasterData.Web.Api.Features/StepDefinitions/StepDefinitions.cs
+++ b/src/MasterData/MasterData.Web.Api.Features/StepDefinitions/StepDefinitions.cs
@@ -1,8 +1,10 @@
-[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]
+// [assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]
 
 namespace DigitalLibrary.MasterData.Web.Api.Features.StepDefinitions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.IO;
     using System.Net.Http;
 
     using DigitalLibrary.MasterData.Web.Api.Client.Interfaces;
@@ -14,8 +16,6 @@ namespace DigitalLibrary.MasterData.Web.Api.Features.StepDefinitions
     using DigitalLibrary.Utils.Guards;
     using DigitalLibrary.Utils.MasterDataTestHelper;
     using DigitalLibrary.Utils.MasterDataTestHelper.Tools;
-
-    using Microsoft.AspNetCore.Mvc.Testing;
 
     using TechTalk.SpecFlow;
 
@@ -31,13 +31,17 @@ namespace DigitalLibrary.MasterData.Web.Api.Features.StepDefinitions
     {
         private ScenarioContext _scenarioContext;
 
-        private readonly IMasterDataTestHelper _masterDataTestHelper;
+        private IMasterDataTestHelper _masterDataTestHelper;
 
         private readonly ITestOutputHelper _testOutputHelper;
 
-        protected readonly WebApplicationFactory<Startup> _host;
+        private IMasterDataHttpClient _masterDataHttpClient;
 
-        private readonly IMasterDataHttpClient _masterDataHttpClient;
+        private string _entityNameWithPath;
+
+        private Random rnd = new Random();
+
+        protected readonly WebApiFeatureTestApplicationFactory<Startup> _host;
 
         public StepDefinitions(
             ScenarioContext scenarioContext,
@@ -52,6 +56,15 @@ namespace DigitalLibrary.MasterData.Web.Api.Features.StepDefinitions
 
             Check.IsNotNull(host);
             _host = host;
+        }
+
+        [BeforeScenario]
+        public void BeforeScenario()
+        {
+            int random = rnd.Next(1, 10000000);
+            string directoryPath = Directory.GetCurrentDirectory();
+            _entityNameWithPath = $"{directoryPath}/master_data_integration_test_{random}.sql";
+            _host.EntityName = _entityNameWithPath;
 
             IStringHelper stringHelper = new StringHelper();
             ISourceFormatFactory sourceFormatFactory = new SourceFormatFactory(stringHelper);
@@ -76,6 +89,12 @@ namespace DigitalLibrary.MasterData.Web.Api.Features.StepDefinitions
                 sourceFormatHttpClientHttpClient,
                 dimensionStructureHttpClient,
                 dimensionStructureNodeHttpClient);
+        }
+
+        [AfterScenario]
+        public void AfterScenario()
+        {
+            File.Delete(_entityNameWithPath);
         }
     }
 }

--- a/src/MasterData/MasterData.Web.Api.Features/StepDefinitions/WebApiFeatureTestApplicationFactory.cs
+++ b/src/MasterData/MasterData.Web.Api.Features/StepDefinitions/WebApiFeatureTestApplicationFactory.cs
@@ -15,9 +15,14 @@ namespace DigitalLibrary.MasterData.Web.Api.Features.StepDefinitions
     public class WebApiFeatureTestApplicationFactory<TStartup> : WebApplicationFactory<TStartup>
         where TStartup : class
     {
+        public string EntityName { get; set; }
+
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            string entityName = $"Data Source=master_data.api.features.db";
+            if (EntityName == null)
+            {
+                throw new Exception(nameof(EntityName));
+            }
 
             builder.ConfigureServices(services =>
             {
@@ -33,7 +38,10 @@ namespace DigitalLibrary.MasterData.Web.Api.Features.StepDefinitions
                     throw new Exception();
                 }
 
-                services.AddDbContext<MasterDataContext>(options => { options.UseSqlite(entityName); });
+                services.AddDbContext<MasterDataContext>(options =>
+                {
+                    options.UseSqlite($"Data Source = {EntityName}");
+                });
                 ServiceProvider sp = services.BuildServiceProvider();
                 using (IServiceScope scope = sp.CreateScope())
                 {


### PR DESCRIPTION
Signed-off-by: Andras-Csanyi <andras.csanyi@pm.me>

# Description

The situation is the same at it was with business logic tests. Since SQLite is used parallelization doesn't work out of the box. You have to solve that every thread works with its own sqlite instance and once the test finishes it removes the sqlite file.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **Refactor**: A change which enhances the code or other aspects of the overall quality
- [ ] **New feature**: A change that adds functionality.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feature: add a border radius to button
    refactor: rework of some component
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->
