### PR TITLE
Feat/delete dimensionstructurenode from middle of the tree

### DIFF
--- a/src/MasterData/MasterData.BusinessLogic.Features.Tests/SourceFormat/DeleteDimensionStructureNodeFromMiddleOfTheTree.feature
+++ b/src/MasterData/MasterData.BusinessLogic.Features.Tests/SourceFormat/DeleteDimensionStructureNodeFromMiddleOfTheTree.feature
@@ -1,0 +1,353 @@
+Feature: SourceFormat Business Logic - Delete DimensionStructureNode from middle of the tree
+
+As a Data Owner and Data Curator
+I need to be able to manage trees describe how a document structures
+Which includes being able to delete nodes
+
+    Scenario: Deletes DimensionStructureNode from middle of the tree
+
+    #      Test case:
+    #      SF
+    #      |-> RootDimensionStructureNode
+    #          |-> DSN (dsn-root-1)
+    #              |-> DSN (dsn-root-1-1)
+    #                |-> DSN (dsn-root-1-1-1)
+    #                  |-> DSN (dsn-root-1-1-1-1)
+    #                  |-> DSN (dsn-root-1-1-1-2)
+    #                  |-> DSN (dsn-root-1-1-1-3)
+    #                |-> DSN (dsn-root-1-1-2)
+    #                  |-> DSN (dsn-root-1-1-2-1)
+    #                  |-> DSN (dsn-root-1-1-2-2)
+    #                  |-> DSN (dsn-root-1-1-2-3)
+    #                |-> DSN (dsn-root-1-1-3)
+    #              |-> DSN (dsn-root-1-2)
+    #              |-> DSN (dsn-root-1-3)
+
+        Given there is a saved SourceFormat domain object
+          | Field     | Value       |
+          | Name      | sf-2        |
+          | Desc      | sf-2        |
+          | IsActive  | 1           |
+          | ResultKey | sf-2-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value          |
+          | IsActive  | 1              |
+          | ResultKey | sf-2-root-node |
+
+        And DimensionStructureNode is added to SourceFormat as root
+          | Field                     | Value                |
+          | DimensionStructureNodeKey | sf-2-root-node       |
+          | SourceFormatKey           | sf-2-result          |
+          | ResultKey                 | sf-1-root-dsn-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value      |
+          | IsActive  | 1          |
+          | ResultKey | dsn-root-1 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value             |
+          | SourceFormatKey                    | sf-2-result       |
+          | ParentDimensionStructureNodeKey    | sf-2-root-node    |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1        |
+          | OperationResultKey                 | dsn-root-1-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value        |
+          | IsActive  | 1            |
+          | ResultKey | dsn-root-1-1 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value               |
+          | SourceFormatKey                    | sf-2-result         |
+          | ParentDimensionStructureNodeKey    | dsn-root-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1        |
+          | OperationResultKey                 | dsn-root-1-1-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value        |
+          | IsActive  | 1            |
+          | ResultKey | dsn-root-1-2 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value               |
+          | SourceFormatKey                    | sf-2-result         |
+          | ParentDimensionStructureNodeKey    | dsn-root-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-2        |
+          | OperationResultKey                 | dsn-root-1-2-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value        |
+          | IsActive  | 1            |
+          | ResultKey | dsn-root-1-3 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value               |
+          | SourceFormatKey                    | sf-2-result         |
+          | ParentDimensionStructureNodeKey    | dsn-root-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-3        |
+          | OperationResultKey                 | dsn-root-1-3-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value          |
+          | IsActive  | 1              |
+          | ResultKey | dsn-root-1-1-1 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                 |
+          | SourceFormatKey                    | sf-2-result           |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-1        |
+          | OperationResultKey                 | dsn-root-1-1-1-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value          |
+          | IsActive  | 1              |
+          | ResultKey | dsn-root-1-1-2 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                 |
+          | SourceFormatKey                    | sf-2-result           |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-2        |
+          | OperationResultKey                 | dsn-root-1-1-2-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value          |
+          | IsActive  | 1              |
+          | ResultKey | dsn-root-1-1-3 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                 |
+          | SourceFormatKey                    | sf-2-result           |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-3        |
+          | OperationResultKey                 | dsn-root-1-1-3-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value            |
+          | IsActive  | 1                |
+          | ResultKey | dsn-root-1-1-1-1 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                   |
+          | SourceFormatKey                    | sf-2-result             |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-1-1        |
+          | OperationResultKey                 | dsn-root-1-1-1-1-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value            |
+          | IsActive  | 1                |
+          | ResultKey | dsn-root-1-1-1-2 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                   |
+          | SourceFormatKey                    | sf-2-result             |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-1-2        |
+          | OperationResultKey                 | dsn-root-1-1-1-2-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value            |
+          | IsActive  | 1                |
+          | ResultKey | dsn-root-1-1-1-3 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                   |
+          | SourceFormatKey                    | sf-2-result             |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1-1          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-1-3        |
+          | OperationResultKey                 | dsn-root-1-1-1-3-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value            |
+          | IsActive  | 1                |
+          | ResultKey | dsn-root-1-1-2-1 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                   |
+          | SourceFormatKey                    | sf-2-result             |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1-2          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-2-1        |
+          | OperationResultKey                 | dsn-root-1-1-2-1-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value            |
+          | IsActive  | 1                |
+          | ResultKey | dsn-root-1-1-2-2 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                   |
+          | SourceFormatKey                    | sf-2-result             |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1-2          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-2-2        |
+          | OperationResultKey                 | dsn-root-1-1-2-2-result |
+
+        And there is a saved DimensionStructureNode domain object
+          | Field     | Value            |
+          | IsActive  | 1                |
+          | ResultKey | dsn-root-1-1-2-3 |
+
+        And DimensionStructureNode is added to the tree of a SourceFormat
+          | Field                              | Value                   |
+          | SourceFormatKey                    | sf-2-result             |
+          | ParentDimensionStructureNodeKey    | dsn-root-1-1-2          |
+          | ToBeAddedDimensionStructureNodeKey | dsn-root-1-1-2-3        |
+          | OperationResultKey                 | dsn-root-1-1-2-3-result |
+
+        When DimensionStructureNode is deleted from tree of SourceFormat
+          | Field                           | Value                      |
+          | DimensionStructureNodeKey       | dsn-root-1-1               |
+          | ParentDimensionStructureNodeKey | sf-2-root-node             |
+          | SourceFormatKey                 | sf-2-result                |
+          | OperationResultKey              | delete-ds-node-to-be-added |
+
+        Then SourceFormat is requested with DimensionStructureNode tree
+          | Field     | Value          |
+          | Key       | sf-2-result    |
+          | ResultKey | sf-2-with-tree |
+
+        And DimensionStructureNode is in the tree by traversing through the tree
+          | Field              | Value          |
+          | Key                | sf-2-with-tree |
+          | SearchForObjectKey | sf-2-root-node |
+
+        And DimensionStructureNode is in the tree by traversing through the tree
+          | Field              | Value          |
+          | Key                | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1     |
+
+        And DimensionStructureNode parent by traversing through the tree is
+          | Field              | Value          |
+          | TreeKey            | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1     |
+          | ParentKey          | sf-2-root-node |
+
+        And DimensionStructureNode parent in the database is
+          | Field     | Value          |
+          | ChildKey  | dsn-root-1     |
+          | ParentKey | sf-2-root-node |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value          |
+          | Key                | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1-1   |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value          |
+          | DimensionStructureNodeKey | dsn-root-1-1   |
+          | SourceFormatKey           | sf-2-with-tree |
+
+        And DimensionStructureNode is in the tree by traversing through the tree
+          | Field              | Value          |
+          | Key                | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1-2   |
+
+        And DimensionStructureNode parent by traversing through the tree is
+          | Field              | Value          |
+          | TreeKey            | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1-2   |
+          | ParentKey          | dsn-root-1     |
+
+        And DimensionStructureNode parent in the database is
+          | Field     | Value        |
+          | ChildKey  | dsn-root-1-2 |
+          | ParentKey | dsn-root-1   |
+
+        And DimensionStructureNode is in the tree by traversing through the tree
+          | Field              | Value          |
+          | Key                | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1-3   |
+
+        And DimensionStructureNode parent by traversing through the tree is
+          | Field              | Value          |
+          | TreeKey            | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1-3   |
+          | ParentKey          | dsn-root-1     |
+
+        And DimensionStructureNode parent in the database is
+          | Field     | Value        |
+          | ChildKey  | dsn-root-1-3 |
+          | ParentKey | dsn-root-1   |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value          |
+          | Key                | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1-1-2 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value          |
+          | DimensionStructureNodeKey | dsn-root-1-1-2 |
+          | SourceFormatKey           | sf-2-with-tree |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value          |
+          | Key                | sf-2-with-tree |
+          | SearchForObjectKey | dsn-root-1-1-3 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value          |
+          | DimensionStructureNodeKey | dsn-root-1-1-3 |
+          | SourceFormatKey           | sf-2-with-tree |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value            |
+          | Key                | sf-2-with-tree   |
+          | SearchForObjectKey | dsn-root-1-1-2-1 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value            |
+          | DimensionStructureNodeKey | dsn-root-1-1-2-1 |
+          | SourceFormatKey           | sf-2-with-tree   |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value            |
+          | Key                | sf-2-with-tree   |
+          | SearchForObjectKey | dsn-root-1-1-2-2 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value            |
+          | DimensionStructureNodeKey | dsn-root-1-1-2-2 |
+          | SourceFormatKey           | sf-2-with-tree   |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value            |
+          | Key                | sf-2-with-tree   |
+          | SearchForObjectKey | dsn-root-1-1-2-3 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value            |
+          | DimensionStructureNodeKey | dsn-root-1-1-2-3 |
+          | SourceFormatKey           | sf-2-with-tree   |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value            |
+          | Key                | sf-2-with-tree   |
+          | SearchForObjectKey | dsn-root-1-1-1-1 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value            |
+          | DimensionStructureNodeKey | dsn-root-1-1-1-1 |
+          | SourceFormatKey           | sf-2-with-tree   |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value            |
+          | Key                | sf-2-with-tree   |
+          | SearchForObjectKey | dsn-root-1-1-1-2 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value            |
+          | DimensionStructureNodeKey | dsn-root-1-1-1-2 |
+          | SourceFormatKey           | sf-2-with-tree   |
+
+        And DimensionStructureNode is not in the tree by traversing through the tree
+          | Field              | Value            |
+          | Key                | sf-2-with-tree   |
+          | SearchForObjectKey | dsn-root-1-1-1-3 |
+
+        And DimensionStructureNode is not in the tree in the database
+          | Field                     | Value            |
+          | DimensionStructureNodeKey | dsn-root-1-1-1-3 |
+          | SourceFormatKey           | sf-2-with-tree   |

--- a/src/MasterData/MasterData.BusinessLogic.Features.Tests/StepDefinitions/StepDefinitions.cs
+++ b/src/MasterData/MasterData.BusinessLogic.Features.Tests/StepDefinitions/StepDefinitions.cs
@@ -6,6 +6,7 @@
 namespace DigitalLibrary.MasterData.BusinessLogic.Features.Tests.StepDefinitions
 {
     using System;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
 
@@ -99,14 +100,16 @@ namespace DigitalLibrary.MasterData.BusinessLogic.Features.Tests.StepDefinitions
             string path = Directory.GetCurrentDirectory();
             string fileName = $"sqlite_{rnd.Next(1, 10000000)}.sqlite";
             sqlLiteFileNameWithPath = $"{path}/{fileName}";
+            _outputHelper.WriteLine($"SQLite file name: {sqlLiteFileNameWithPath}");
 
             _dbContextOptions = new DbContextOptionsBuilder<MasterDataContext>()
                .UseSqlite($"Data Source = {sqlLiteFileNameWithPath}")
+               .LogTo(msg => Debug.WriteLine(msg))
+               .EnableDetailedErrors()
+               .EnableSensitiveDataLogging()
                 // .UseNpgsql("Server=127.0.0.1;Port=5432;Database=dilib;User Id=andrascsanyi;")
                 // .UseLoggerFactory(MasterDataLogger)
                 // .UseInternalServiceProvider(_serviceProvider)
-                // .EnableDetailedErrors()
-                // .EnableSensitiveDataLogging()
                .Options;
 
             DimensionValidator dimensionValidator = new DimensionValidator();

--- a/src/MasterData/MasterData.BusinessLogic.Implementations/SourceFormat/GetSourceFormatByIdWithFullDimensionStructureTreeAsync.cs
+++ b/src/MasterData/MasterData.BusinessLogic.Implementations/SourceFormat/GetSourceFormatByIdWithFullDimensionStructureTreeAsync.cs
@@ -33,7 +33,6 @@ namespace DigitalLibrary.MasterData.BusinessLogic.Implementations.SourceFormat
                     SourceFormat sourceFormat = await ctx.SourceFormats
                        .Include(i => i.SourceFormatDimensionStructureNode)
                        .ThenInclude(ii => ii.DimensionStructureNode)
-                       .ThenInclude(iii => iii.DimensionStructure)
                        .AsNoTracking()
                        .FirstAsync(p => p.Id == querySourceFormat.Id)
                        .ConfigureAwait(false);


### PR DESCRIPTION
# Description

From now on when a DimensionStructureNode is deleted from any place from the tree the child nodes/child tree is going to be deleted too. As a result later cleanup is not necessary to deal with orphan elements.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **Refactor**: A change which enhances the code or other aspects of the overall quality
- [x] **New feature**: A change that adds functionality.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feature: add a border radius to button
    refactor: rework of some component
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->
